### PR TITLE
Fix deploy action

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -42,7 +42,7 @@ jobs:
           echo "Updating release v$version"
           echo "---------------------------"
           echo -e "Gauge Screenshot v$version\n\n" > desc.txt
-          release_description=$(ruby -e "$(curl -sSfL https://github.com/getgauge/gauge/raw/master/build/create_release_text.rb)" gauge_screenshot getgauge)
+          release_description=$(ruby -e "$(curl -sSfL https://github.com/getgauge/gauge/raw/master/build/create_release_text.rb)" getgauge gauge_screenshot)
           echo "$release_description" >> desc.txt
           echo "Creating new draft for release v$version"
           hub release create -d -F ./desc.txt "v$version"


### PR DESCRIPTION
The deploy step failed: https://github.com/getgauge/gauge_screenshot/runs/2995137249?check_suite_focus=true#step:6:38 and I guess due https://github.com/getgauge/gauge_screenshot/blob/master/.github/workflows/github_release.yml#L45 where `gauge_screenshot getgauge` needs to be swapped.