### PR TITLE
Remove CGO from Windows builds

### DIFF
--- a/build/make.go
+++ b/build/make.go
@@ -50,7 +50,6 @@ const (
 	gaugeScreenshot   = "gauge_screenshot"
 	deploy            = "deploy"
 	pluginJSONFile    = "plugin.json"
-	CC                = "CC"
 )
 
 var deployDir = filepath.Join(deploy, screenshot)
@@ -276,12 +275,12 @@ var binDir = flag.String("bin-dir", "", "Specifies OS_PLATFORM specific binaries
 
 var (
 	platformEnvs = []map[string]string{
-		map[string]string{GOARCH: x86_64, goOS: DARWIN, CGO_ENABLED: "0"},
-		map[string]string{GOARCH: ARM64, goOS: DARWIN, CGO_ENABLED: "0"},
-		map[string]string{GOARCH: x86_64, goOS: LINUX, CGO_ENABLED: "0"},
-		map[string]string{GOARCH: ARM64, goOS: LINUX, CGO_ENABLED: "0"},
-		map[string]string{GOARCH: x86_64, goOS: WINDOWS, CC: "x86_64-w64-mingw32-gcc", CGO_ENABLED: "1"},
-		map[string]string{GOARCH: ARM64, goOS: WINDOWS, CC: "aarch64-w64-mingw32-gcc", CGO_ENABLED: "1"},
+		{GOARCH: x86_64, goOS: DARWIN, CGO_ENABLED: "0"},
+		{GOARCH: ARM64, goOS: DARWIN, CGO_ENABLED: "0"},
+		{GOARCH: x86_64, goOS: LINUX, CGO_ENABLED: "0"},
+		{GOARCH: ARM64, goOS: LINUX, CGO_ENABLED: "0"},
+		{GOARCH: x86_64, goOS: WINDOWS, CGO_ENABLED: "0"},
+		{GOARCH: ARM64, goOS: WINDOWS, CGO_ENABLED: "0"},
 	}
 )
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id" : "screenshot",
-    "version" : "0.3.1",
+    "version" : "0.3.2",
     "name" : "Screenshot",
     "description" : "cross-platform command line screenshot utility",
     "scope" : [],

--- a/version/version.go
+++ b/version/version.go
@@ -18,4 +18,4 @@
 
 package version
 
-var Version = "0.3.1"
+var Version = "0.3.2"


### PR DESCRIPTION
This should no longer be required; the dependent libraries are all CGO-free.

Will use this as a sort of test run for https://github.com/getgauge/gauge/pull/2751