### PR TITLE
Bump version to 1.0.1 to address CVE-2026-39836

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id" : "screenshot",
-    "version" : "1.0.0",
+    "version" : "1.0.1",
     "name" : "Screenshot",
     "description" : "cross-platform command line screenshot utility",
     "scope" : [],

--- a/version/version.go
+++ b/version/version.go
@@ -18,4 +18,4 @@
 
 package version
 
-var Version = "1.0.0"
+var Version = "1.0.1"


### PR DESCRIPTION
- Updated plugin.json version from 1.0.0 to 1.0.1
- Updated version/version.go to reflect new version
- Addresses CVE-2026-39836 (high severity) in net package
- Requires Go 1.26.3 for complete fix